### PR TITLE
Updated installing PASW tile

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -30,7 +30,7 @@ There are two settings in the PAS tile that affect the Windows cells installed b
 
 1. Click **+** under the **PAS for Windows** product listing to add it to your staging area.
 
-##<a id='config'></a> Step 3: Configure and Deploy the Tile
+##<a id='config'></a> Step 3: Configure the Tile
 
 1. Click the newly added **PAS for Windows** tile.
 
@@ -60,31 +60,92 @@ There are two settings in the PAS tile that affect the Windows cells installed b
 
 1. (Optional) To deploy your PAS for Windows application workloads to an isolation segment, click **Application Containers** and perform the steps in the [Assign a Tile to an Isolation Segment](#assign-isolation) section below.
 
-1. (Optional) If an antivirus scanner runs on your VMs, configure the scanner to let the BOSH agent download and uncompress files. See [Configure Antivirus for Windows Cells](#antivirus) for details.
-
 1. (Optional) To configure Windows cells to send Windows Event logs to an external syslog server, click **System Logging** and perform the steps in the [Send Cell Logs to a Syslog Server](./troubleshooting.html#syslog) section.
 
 1. Click **Errands**. Pivotal recommends that you set the **Install HWC Buildpack Errand** to **On**. This ensures that you receive the most up-to-date HWC Buildpack.
     
     <%= image_tag('errands-hwc.png') %>
 
-1. Click **Resource Config** and adjust the number and VM types of your Windows cells as needed. If you are deploying PAS for Windows on Azure, see the [Configure Resources](./stemcells.html#req) section of the *Downloading or Creating Windows Stemcells* topic.
+1. Click **Save**.
+
+
+##<a id='resources'></a> Step 4: Configure Tile Resources
+
+The size of the Windows stemcell's disk determines the minimum disk size of any Windows VM that the BOSH Director can create from that stemcell. The relationship between a stemcell's disk size and the disk size of the Windows cells depends on your IaaS as shown in the table below.
+
+<table id='disk-sizes' border="1" class="nice" >
+  <tr>
+    <th>IaaS</th>
+    <th>Stemcell disk size</th>
+    <th>Possible disk sizes for Windows cells</th>
+  </tr>
+  <tr>
+    <th>Azure</th>
+    <td>127 GB</td>
+    <td>127 GB</td>
+  </tr>
+  <tr>
+    <th>AWS</th>
+    <td>30 GB</td>
+    <td>30 GB or larger</td>
+  </tr>
+  <tr>
+    <th>GCP</th>
+    <td>50 GB</td>
+    <td>50 GB or larger</td>
+  </tr>
+  <tr>
+    <th>vSphere</th>
+    <td>Recommended 128 GB+<sup>*</sup></td>
+    <td>Same as stemcell minimum root disk size</td>
+  </tr>
+</table>
+
+<sup>\*</sup>Because you create your own stemcell on vSphere, you can control its root disk size. See [Creating a vSphere Stemcell Manually](./vsphere-stemcell-build.html) for more information.
+
+### Select Diego Cell disk sizes
+
+When you deploy or upgrade PAS for Windows, configure the resources of the BOSH Director and PAS for Windows as follows:
+
+1. On the Ops Manager Installation Dashboard, select **Pivotal Application Service for Windows**.
+
+1. In the **Settings** tab, select **Resource Config**.
+
+1. In the **VM Type** field, ensure that **Windows Diego Cell** has a minimum disk size according to the table above and your IaaS.
 
 1. Click **Save**.
 
-1. Click **Stemcell**. Record the stemcell version number required by the tile. 
+### Select Master Compilation VM disk size
 
-    <%= image_tag('pcf-windows-tile-stemcell.png') %>
+1. On the Ops Manager Installation Dashboard, select the **BOSH Director** tile.
+
+1. In the **Settings** tab, select **Resource Config**.
+
+1. In the **VM Type** field, ensure that the Ops Manager compilation VM has a minimum disk size according to the table above and your IaaS.
+
+	<%= image_tag('ops-man-resources.png') %>
+
+1. Click **Save**.
+
+
+##<a id='resources'></a> Step 5: Upload the Stemcell
+
+1. On the Ops Manager Installation Dashboard, in **Pivotal Application Service for Windows**, click on **Missing Stemcell**. You will be taken to the **Stemcell Library.**
 
 1. Retrieve the stemcell that you downloaded or created in [Downloading or Creating a Windows Stemcell](./stemcells.html).
 
-1. Click **Save**.
+1. Follow the steps in [Importing and Managing Stemcells](http://docs-pcf-staging.cfapps.io/pivotalcf/2-1/opsguide/managing-stemcells.html) to upload the Windows stemcell to **Pivotal Application Service for Windows.**
+
+
+##<a id='deploy'></a> Step 6: Deploy the Tile
 
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to install the PAS for Windows tile.
 
-##<a id='copy'></a> Step 4: (Optional) Create More Tiles
+
+##<a id='copy'></a> Step 7: (Optional) Create More Tiles
 
 If you want to run Windows cells in multiple isolation segments, you must create and configure additional PAS for Windows tiles. See [Windows Cells in Isolation Segments](#isolation) below for how to do this.
+
 
 ##<a id='isolation'></a> Windows Cells in Isolation Segments
 
@@ -136,11 +197,3 @@ To assign a PAS for Windows tile to an isolation segment, perform the following 
 
 1. If you are creating a new isolation segment, follow the steps in the [Create an Isolation Segment](https://docs.pivotal.io/pivotalcf/adminguide/isolation-segments.html#create-an-is) section of the <em>Managing Isolation Segments</em> topic to add the isolation segment to the CCDB.
 
-##<a id='antivirus'></a> Configure Antivirus for Windows Cells
-
-Diego cell VMs routinely download and uncompress files, while antivirus scanners scan files once they are downloaded or uncompressed. When an antivirus scanner program runs in a directory that BOSH is actively downloading or compressing into, scanner actions can block BOSH processes and cause hard-to-debug “Access is denied” errors.
-
-To prevent these errors, configure your antivirus scanner to disable **on-access scanning** for the following directories on your Windows cell:
-
-* `C:\bosh`
-* `C:\var\vcap`


### PR DESCRIPTION
- Inserted necessary disk sizing step, which applies to all IaaSes.
- Removed A/V config, which cannot be done during this process.
- Separated steps to accommodate disk sizing table and text.
- Referenced the pre-existing stemcell upload steps from PAS.