### PR TITLE
Removing description of shutdown events

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -23,14 +23,6 @@ If you have upgraded to PAS for Windows and have apps that you want to migrate, 
 
 The [.NET Cookbook](https://dotnet-cookbook.cfapps.io/intro/) has useful tips and recipes for developing .NET apps to run on PAS for Windows.
 
-###<a id='shutdown'></a> Handle Shutdown Events
-
-To gracefully handle system shutdown events, .NET apps running on PAS for Windows cells need to include a control handler function that responds to `CTRL_CLOSE_EVENT` and `CTRL_SHUTDOWN_EVENT` system event messages.
-
-PAS for Windows apps do not receive `CTRL_C_EVENT`, `CTRL_BREAK_EVENT`, or `CTRL_LOGOFF_EVENT` messages, so your control handler can ignore them.
-
-For guidance, see the [Registering a Control Handler Function](https://docs.microsoft.com/en-us/windows/console/registering-a-control-handler-function) and [SetConsoleCtrlHandler function](https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler) topics in the Microsoft documentation.
-
 ##<a id='push'></a> Push a .NET App
 
 By default, PCF serves .NET apps with Hostable Web Core (HWC). HWC is a lighter version of the Internet Information Services (IIS) server that contains the core IIS functionality.


### PR DESCRIPTION
These steps do not provide a consistent shutdown experience and thus don't make a good recommendation for .NET applications.