### PR TITLE
Removing AWS Limitation from PASW 2.2, 2.1

### DIFF
--- a/docs-content/stemcells.html.md.erb
+++ b/docs-content/stemcells.html.md.erb
@@ -16,7 +16,7 @@ BOSH needs a stemcell to supply the basic operating system for any new Windows S
 
 * **vSphere**: Create a stemcell by following the directions in [Creating a vSphere Stemcell by Hand](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Creating-a-vSphere-Stemcell-by-Hand).
 
-* **AWS**: Currently, _AWS does not provide the version of Windows required by PAS for Windows_, Windows Server version 1709. Contact your AWS representative for information regarding the availability of this OS version.
+* **AWS**: Download the **AWS light Stemcell for Windows 2016 Server Version 1709** from the **Stemcells for PCF (Windows Server)** section of [Pivotal Network](https://network.pivotal.io/products/stemcells-windows-server).
 
 
 ## <a id="azure"></a> Configuring the Azure Light Stemcell


### PR DESCRIPTION
This needs to be backported to PASW 2.1 documentation as well. 

Also, this needs to go live in conjunction with the release notes of 1709.11, as well as the PivNet public release of 1709.11