### PR TITLE
Added Windows command line clarification. Fixes feature-48.

### DIFF
--- a/docs-content/create-vsphere-stemcell-automatically.html.md.erb
+++ b/docs-content/create-vsphere-stemcell-automatically.html.md.erb
@@ -175,7 +175,7 @@ Before constructing the BOSH stemcell, collect the following information:
 * vCenter inventory path to the target VM in the `/MY-DATA-CENTER/vm/MY-FOLDER/MY-VM` format where:
   * `MY-DATA-CENTER` is the name of the data center.
   * `vm` is a static string.
-  * `MY-FOLDER` is the name of the folder that contains the VM.
+  * `MY-FOLDER` is the name of the folder that contains the VM. If your VM is not contained in a folder, omit this part and one of the slash separators.
   * `MY-VM` is the name of the target VM.
 * vCenter username
 * vCenter password
@@ -226,6 +226,8 @@ Before packaging the BOSH stemcell, collect the following information:
 * vCenter username
 * vCenter password
 * vCenter URL
+
+You must also now shutdown the VM before running the package command. If you do not, it will fail stating that the storage location for the VM could not be read.
 
 To package the BOSH stemcell, run the following command from your local host:
 
@@ -283,23 +285,46 @@ vcenter_client - unable to validate url: vcenter.example.com
 `stembuild` uses govc libraries. These libraries cannot parse the special characters
 `/`, `#`, and `:`. This results in errors when authenticating with vCenter.
 
+You may also experience this issue on Windows if your password includes a single quote character. This also affects the Inventory path if it contains a single quote or a space.
+
 **Workaround**
 
-If your vCenter username or password contains `/`, `#`, or `:`, set the following environment variables:
+If your vCenter username or password contains `/`, `#`, or `:`, or `'` on Windows, set the following environment variables
 
+On Linux:-
 ```
 export GOVC_USERNAME=VCENTER-USERNAME
 export GOVC_PASSWORD=VCENTER-PASSWORD
 ```
+
+On Windows:-
+```
+set GOVC_USERNAME=VCENTER-USERNAME
+set GOVC_PASSWORD=VCENTER-PASSWORD
+set GOVC_PATH=VCENTER-INVENTORY-PATH
+```
+
 Where:
 
 - `VCENTER-USERNAME` is your vCenter account username. For example, `johndoe`.
 - `VCENTER-PASSWORD` is your vCenter account password. For example, `pass#word`.
+- `VCENTER-INVENTORY-PATH` is the location of your VM in the cluster inventory.
 
-If you are using other special characters, add single quotes around the input parameters. 
-For example:
+If you are using other special characters, add single quotes around the input parameters, or set them in an environment variable as described above. 
+
+For example, on Linux:-
 
 ```
 ./STEMBUILD-BINARY package -vcenter-url VCENTER-URL -vcenter-username 'admin@' -vcenter-password VCENTER-PASSWORD -vm-inventory-path INVENTORY-PATH
 ```
 
+Or on Windows:-
+
+```
+set GOVC_PASSWORD=A_Strange!PAssword@Here#1
+./STEMBUILD-BINARY package -vcenter-url VCENTER-URL -vcenter-username %GOVC_USERNAME% -vcenter-password %GOVC_PASSWORD% -vm-inventory-path %GOVC_PATH%
+```
+
+<p class='note'><strong>Note:</strong> On Windows, the environment variables
+are not automatically used instead of the vcenter command line parameters. 
+This is why they are specified in the command line above.</p>


### PR DESCRIPTION
Added description of how to use Windows set to specify vcenter username and password. Also added command line examples. 

In addition, added a step that I found necessary - shutting down the VM before running package. When trying today on windows 2019 it wouldn't run unless the VM was shutdown.

My first commit to this repo. Please check through for style and flow.