### PR TITLE
Windows: A note about the legacy windows2016 stack

### DIFF
--- a/docs-content/migrating.html.md.erb
+++ b/docs-content/migrating.html.md.erb
@@ -65,6 +65,10 @@ Perform the following steps to redeploy a running app with zero downtime using t
     <code>--no-start</code> is used to create the instance VMs and not start the app, and <code>--no-route</code> is used to prevent the push command from automatically mapping a route to the app.
     For additional information about <code>cf push</code>, see <a href="http://cli.cloudfoundry.org/en-US/cf/push.html">cf push</a>.</p>
 
+    <p class="note"><strong>Note</strong>: The stack <code>-s windows</code> is a rename of the old <code> -s windows2016</code> stack. They are both exactly the same.
+    If the stack <code>windows</code> is available you should use it, otherwise you can use the <code>windows2016</code>. As of PASW 2.5, the usage of the <code>windows2016</code> stack is considered deprecated, and is completely removed from PASW 2.8.
+    For more information, please see the <a href="https://docs.pivotal.io/pivotalcf/2-5/pcf-release-notes/windows-rn.html#-deprecation-of-the-windows2016-stack">PASW 2.5 release notes</a></p>
+
 1. To configure the router so all incoming requests go to both `APP-NAME` and `APP-NAME-green` run the following command:
 
     ```shell


### PR DESCRIPTION
There's a chance that users encounter the now deprecated
"windows2016" stack and get confused. Let them know what
the deal is.

Could you please also add this to docs for all releases < 2.8?