### PR TITLE
Removing the GoRouter to Windows Container TLS limitation

### DIFF
--- a/docs-content/architecture.html.md.erb
+++ b/docs-content/architecture.html.md.erb
@@ -53,5 +53,3 @@ The BOSH Agent executes and monitors BOSH jobs on its VM.
 Deployments of Windows Server on <%= vars.product_name %> currently use a stemcell containing Windows Server 2019.
 
 See [Downloading or Creating Windows Stemcells](./stemcells.html) for documentation about how to obtain or create a stemcell for PAS for Windows.
-
-<p class="note"><strong>Note:</strong> Traffic between the Gorouter and Windows stemcells is not encrypted with TLS.</p>


### PR DESCRIPTION
With PASW 2.7 there's now an option to encrypt GoRouter to Windows Container TLS. We can remove this from PASW 2.7+ onwards.