### PR TITLE
NCP limitation for PASW

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -70,6 +70,7 @@ The minimum resource requirements for each Windows cell are as follows:
 
 PAS for Windows has the following limitations:
 
+* PASW can be installed in an OpsManager environment with NCP, but [NCP](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.5/rn/NSX-Container-Plugin-25-Release-Notes.html) cannot be used with Windows Containers in PASW
 * Developers cannot push Docker or other OCI-compatible images to Windows Diego cells.
 * Container-to-container networking is not available for Windows-hosted applications.
 * OpenStack is currently not supported for PAS for Windows. Contact your Pivotal representative for information about OpenStack deployments.


### PR DESCRIPTION
NSX-T, and specifically NCP can be installed on an environment with PASW. But NCP cannot be used to manage Windows containers in PASW. We should have more explicit documentation across our docs regarding this. 