### PR TITLE
Revert notice of windows2016 stack removal

### DIFF
--- a/docs-content/migrating.html.md.erb
+++ b/docs-content/migrating.html.md.erb
@@ -66,8 +66,8 @@ Perform the following steps to redeploy a running app with zero downtime using t
     For additional information about <code>cf push</code>, see <a href="http://cli.cloudfoundry.org/en-US/cf/push.html">cf push</a>.</p>
 
     <p class="note"><strong>Note</strong>: The <code>windows</code> stack is a renaming of the old <code>windows2016</code> stack. These stacks are identical and differ in name only.
-    If the <code>windows</code> stack is available, specify <code>-s windows</code>. Otherwise, specify <code>-s windows2016</code>. Starting in PAS for Windows v2.5, the <code>windows2016</code> stack is deprecated, 
-    and in PAS for Windows v2.8, the <code>windows2016</code> stack will be removed completely.
+    If the <code>windows</code> stack is available, specify <code>-s windows</code>. Otherwise, specify <code>-s windows2016</code>. Starting in PAS for Windows v2.5, the <code>windows2016</code> stack is deprecated. 
+
     For more information, please see the <a href="https://docs.pivotal.io/platform/2-5/pcf-release-notes/windows-rn.html#-deprecation-of-the-windows2016-stack">PAS for Windows v2.5 release notes</a>.</p>
 
 1. To configure the router so all incoming requests go to both `APP-NAME` and `APP-NAME-green` run the following command:


### PR DESCRIPTION
The garden-windows team no longer plans to remove the `windows2016` stack for PAS `2.8`. The stack will still be available, albeit deprecated.