### PR TITLE
Windows containers support Lucida font, not Arial

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -84,7 +84,7 @@ The following are known Windows Server Container limitations:
 
 * Windows Server Core containers support the host VM's timezone only.
 In <%= vars.windows_runtime_abbr %>, the host and container time-zone is always UTC.
-* Windows Server 2019 Core images support only Arial font.
+* Windows Server 2019 Core images support only Lucida Console font.
 No other fonts are supported, and no others can be installed.
 
 #### <a id='limitations-pasw'></a> <%= vars.windows_runtime_abbr %> Limitations


### PR DESCRIPTION
We need to update the documentation for Windows containers to show the proper font type available. Currently, the docs incorrectly show `Arial` as supported.  It should say `Lucida Console`.