### PR TITLE
Stemcell Compatibility Matrix

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -10,6 +10,8 @@ This topic contains release notes for <%= vars.windows_runtime_full %> <%= vars.
 Because VMware uses the Percona Distribution for MySQL, expect a time lag between Oracle
 releasing a MySQL patch and VMware releasing <%= vars.windows_runtime_abbr %> containing that patch.
 
+Refer to the [stemcell compatibility matrix](./stemcells.html) before installing your tile.
+
 ## <a id='releases'></a> Releases
 
 <%# DO NOT DELETE THIS LINE - robots use this to add new release notes %>

--- a/stemcells.html.md.erb
+++ b/stemcells.html.md.erb
@@ -24,7 +24,7 @@ in the Cloud Foundry BOSH documentation.
 
 Refer to the compatibility matrix below before deploying and installing the TASW tile:
 
-| TASW Version        | WinFSInjector version | 2019.43 and earlier | 2019.44 for Azure and Stembuild vSphere | 2019.44 for other IAASes |
+| TASW Version        | WindowsFS Version     | 2019.43 and earlier | 2019.44 for Azure and Stembuild vSphere | 2019.44 for other IAASes |
 |---------------------|-----------------------|---------------------|-----------------------------------------|--------------------------|
 | 2.7.35 and earlier  | 2.31.0 and earlier    | Compatible          | Not compatible                          | Compatible               |
 | 2.7.37              | 2.33.2                | Compatible          | Compatible                              | Compatible               |

--- a/stemcells.html.md.erb
+++ b/stemcells.html.md.erb
@@ -22,6 +22,19 @@ A typical BOSH stemcell for Windows contains the following:
 For more information about stemcells, see [What is a Stemcell?](https://bosh.io/docs/stemcell/) 
 in the Cloud Foundry BOSH documentation.  
 
+Refer to the compatibility matrix below before deploying and installing the TASW tile:
+
+| TASW Version        | WinFSInjector version | 2019.43 and earlier | 2019.44 for Azure and Stembuild vSphere | 2019.44 for other IAASes |
+|---------------------|-----------------------|---------------------|-----------------------------------------|--------------------------|
+| 2.7.35 and earlier  | 2.31.0 and earlier    | Compatible          | Not compatible                          | Compatible               |
+| 2.7.37              | 2.33.2                | Compatible          | Compatible                              | Compatible               |
+| 2.10.19 and earlier | 2.31.9 and earlier    | Compatible          | Not compatible                          | Compatible               |
+| 2.10.21             | 2.33.2                | Compatible          | Compatible                              | Compatible               |
+| 2.11.8 and earlier  | 2.31.0 and earlier    | Compatible          | Not compatible                          | Compatible               |
+| 2.11.10             | 2.33.2                | Compatible          | Compatible                              | Compatible               |
+| 2.12.3 and earlier  | 2.31.0 and earlier    | Compatible          | Not compatible                          | Compatible               |
+| 2.12.4              | 2.33.2                | Compatible          | Compatible                              | Compatible               |
+
 <br>
 Depending on your IaaS, you can create or download a stemcell using these methods:
 


### PR DESCRIPTION
Due to the recent changes in Windows stemcells, customers need to make sure they are using the compatible versions of WinFS Injector tool and Windows stemcells. 

This PR adds a table to the stemcells page and also a link to it from the release notes.