### PR TITLE
Document syslog drain breaking change (2.12)

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -23,6 +23,7 @@ Before you install the tile, refer to the [Windows Stemcell Compatibility Matrix
 
 **Release Date:** 04/20/2022
 
+* **[Breaking Change]** Syslog drains configured to use TLS now [reject certificates signed with the SHA-1 hash function](https://go.dev/doc/go1.18#sha1).
 * Bump diego to version `2.62.0`
 * Bump hwc-offline-buildpack to version `3.1.24`
 * Bump metrics-discovery to version `3.0.10`


### PR DESCRIPTION
- Certificates using SHA-1 will now be rejected
- This is a result of bumping loggregator-agent-release to Go 1.18
- We expect most users to be unaffected