### PR TITLE
Document syslog drain breaking change (2.13)

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -22,6 +22,7 @@ Before you install the tile, refer to the [Windows Stemcell Compatibility Matrix
 
 <p class="note warning"><strong> Warning:Upcoming breaking changes!</strong> In future patches, no sooner than July 1st 2022, some components will become more strict about the protocols used in TLS communications, causing integrations with systems using older, insecure protocols to fail. Specifically, components using the Go programming language will be updated to Go 1.18, and will no longer support TLS 1.0 and 1.1 connections or certificates with a SHA-1 checksum. This is most likely to affect connections with external databases. However, the pre-existing configuration for "TLS versions supported by the Gorouter" will still work. This change may not arrive all at once, as Go is used in systems throughout TAS. There will be a VMware Knowledge Base article about this change published prior to the changes rolling out. These changes will be clearly designated in the release notes of the versions they ship in; a version of this warning will appear on all patch versions until we are confident no systems remain to be updated.</p>
 
+* **[Breaking Change]** Syslog drains configured to use TLS now [reject certificates signed with the SHA-1 hash function](https://go.dev/doc/go1.18#sha1).
 * Bump diego to version `2.64.0`
 * Bump garden-runc to version `1.20.6`
 * Bump loggregator-agent to version `6.4.1`


### PR DESCRIPTION
- Certificates using SHA-1 will now be rejected
- This is a result of bumping loggregator-agent-release to Go 1.18
- We expect most users to be unaffected