### PR TITLE
Note that BOSH_ALL_PROXY can break winfs-injector

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -88,6 +88,14 @@ To install the <%= vars.windows_runtime_abbr %> tile:
 
     This step take up to 20 minutes to complete.
 
+    **Note**: If you have the `BOSH_ALL_PROXY` environment variable set, this can cause the `winfs-injector` to fail, with an error like the following:
+
+    ```
+    -- Failed downloading 'golang-1-windows/789a42163ee8b705cfcd8a62e590d5cbf01322c773497d6c53247cf6a4e39965' (sha1=sha256:55db4fe9804edfff5f01c5cee0d2541333a71f40c905135912c9c22783e038c1)
+    ```
+
+    If this happens, try unsetting the `BOSH_ALL_PROXY` environment variable, and trying again.
+
 1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product**.
 
 1. To add the <%= vars.windows_runtime_abbr %> tile to the **Import a Product** product list,


### PR DESCRIPTION
This is because the injector uses the bosh-cli library under the hood when it downloads blobs like golang-1-windows:

https://github.com/pivotal-cf/winfs-injector/blob/master/winfsinjector/release_creator.go#L59

If you set BOSH_ALL_PROXY, then it attempts to use that proxy, which can get in the way of actually connecting to the S3 bucket where the blob is stored.

See this slack conversation for details: https://vmware.slack.com/archives/C05666253/p1678987690990709?thread_ts=1678987447.015169&cid=C05666253

[#184606382]