### PR TITLE
Add warning for potential port conflicts

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -291,6 +291,9 @@ configuration in this field. See the [OpenTelemetry Collector documentation](htt
 of how to configure exporters. Currently <%= vars.windows_runtime_abbr %> provides support for a limited number of OpenTelemetry Collector Exporters, including the
 OTLP exporter. This feature is in beta and may still change in significant ways.
 
+  <p class='note warning'><strong>Caution:</strong> If configuring a metric exporter that listens on a port, take care to ensure that the port is not claimed by
+  a <%= vars.windows_runtime_abbr %> component on any of the VMs in your deployment.</p>
+
 ### <a id='dns-search-domains'></a> Configuring DNS search domains (optional)
 
 To configure DNS search domains for your application containers:


### PR DESCRIPTION
- There is potential for a metric exporter to listen on a port that a system component needs to use.
- Ideally we might link here to a port reference for all ports in use within TASW.
- I believe our docs on port usage are focused on configuration of firewall rules. Here the operator may need to ensure that they also don't conflict with system components that only listen on the local interface.